### PR TITLE
feat: adds dataAttributes to linkPressTargetToOnDOMLinkPressArgs in plugins-core

### DIFF
--- a/packages/plugins-core/src/__tests__/linkPressTargetToOnDOMLinkPressArgs.test.ts
+++ b/packages/plugins-core/src/__tests__/linkPressTargetToOnDOMLinkPressArgs.test.ts
@@ -12,7 +12,8 @@ describe('linkPressTargetToOnDOMLinkPressArgs', () => {
         href: 'https://google.com/',
         hreflang: 'en',
         id: 'anchor03',
-        target: '_blank'
+        target: '_blank',
+        data: { custom: 'data' }
       },
       '_blank'
     ];
@@ -31,7 +32,8 @@ describe('linkPressTargetToOnDOMLinkPressArgs', () => {
         relAttribute: null,
         targetAttribute: '_blank',
         typeAttribute: null,
-        uri: 'https://google.com/'
+        uri: 'https://google.com/',
+        dataAttributes: { custom: 'data' }
       })
     ).toEqual(expectedOutput);
   });

--- a/packages/plugins-core/src/linkPressTargetToOnDOMLinkPressArgs.ts
+++ b/packages/plugins-core/src/linkPressTargetToOnDOMLinkPressArgs.ts
@@ -19,7 +19,8 @@ export default function linkPressTargetToOnDOMLinkPressArgs({
   nameAttribute,
   referrerpolicyAttribute,
   relAttribute,
-  typeAttribute
+  typeAttribute,
+  dataAttributes
 }: LinkPressTarget): Parameters<Required<RenderersProps['a']>['onPress']> {
   const attributes = {
     class: classAttribute,
@@ -31,7 +32,8 @@ export default function linkPressTargetToOnDOMLinkPressArgs({
     referrerpolicy: referrerpolicyAttribute,
     rel: relAttribute,
     type: typeAttribute,
-    target: targetAttribute
+    target: targetAttribute,
+    data: dataAttributes
   };
   for (const name in attributes) {
     if (attributes[name] == null) {


### PR DESCRIPTION
formidable-webview/webshell has added dataAttributes to LinkPressTarget in September 2021. [1]

This commit adds it to linkPressTargetToOnDOMLinkPressArgs so that data attributes on anchor tags are available in onPress-handlers.

[1] https://github.com/formidable-webview/webshell/commit/0a2c3e0044c78c8f55800c57c4f9d472b5af65c3