### PR TITLE
Chore/release 14 04 2026

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
     "@native-html/heuristic-table-plugin": "workspace:*",
     "@native-html/iframe-plugin": "workspace:*",
     "@native-html/plugins-core": "workspace:*",
-    "@native-html/render": "1.0.0-alpha.0",
+    "@native-html/render": "1.0.2",
     "@native-html/table-plugin": "workspace:*",
     "@react-native-community/masked-view": "0.1.11",
     "@react-navigation/native": "^7.1.31",

--- a/packages/heuristic-table-plugin/CHANGELOG.md
+++ b/packages/heuristic-table-plugin/CHANGELOG.md
@@ -1,5 +1,21 @@
-# [0.7.0](https://github.com/native-html/plugins/compare/@native-html/heuristic-table-plugin@0.6.0...@native-html/heuristic-table-plugin@0.7.0) (2021-10-13)
+# Change Log
 
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [1.0.0-alpha.0](github.com/native-html/plugins/compare/@native-html/heuristic-table-plugin@0.7.0...@native-html/heuristic-table-plugin@1.0.0-alpha.0) (2026-04-14)
+
+### Bug Fixes
+
+* adjust tests after version bump ([bab83b9](github.com/native-html/plugins/commits/bab83b94a79d2ac9d658c7e44665381ae79f4021)) - by @5ZYSZ3K
+
+### Features
+
+* fix example app and switch from react-native-render-html to @native-html/render ([5cd0239](github.com/native-html/plugins/commits/5cd0239140bce1610186fcc1a8921f1f35ef4337)) - by @5ZYSZ3K
+* upgrade @native-html/render to a stable version ([bb25566](github.com/native-html/plugins/commits/bb25566282fb604f7fb4f747ec72428934d9f4d0)) - by @5ZYSZ3K
+* upgrade all packages and bring libraries to work ([228ce17](github.com/native-html/plugins/commits/228ce174f2598c2aa6ed9b78fcd1f0d43d439d0a)) - by @5ZYSZ3K
+
+# [0.7.0](https://github.com/native-html/plugins/compare/@native-html/heuristic-table-plugin@0.6.0...@native-html/heuristic-table-plugin@0.7.0) (2021-10-13)
 
 ### Features
 
@@ -7,13 +23,11 @@
 
 # [0.6.0](https://github.com/native-html/plugins/compare/@native-html/heuristic-table-plugin@0.5.0...@native-html/heuristic-table-plugin@0.6.0) (2021-06-08)
 
-
 ### Features
 
 * **heuristic-table:** support react-native-render-html@6.0.0-beta.0 ([ffa4f2c](https://github.com/native-html/plugins/commit/ffa4f2c17322e2bb69a58617c2a31b38a246bdb7))
 
 # [0.5.0](https://github.com/native-html/plugins/compare/@native-html/heuristic-table-plugin@0.4.0...@native-html/heuristic-table-plugin@0.5.0) (2021-05-21)
-
 
 ### Features
 
@@ -21,13 +35,11 @@
 
 # [0.4.0](https://github.com/native-html/plugins/compare/@native-html/heuristic-table-plugin@0.3.4...@native-html/heuristic-table-plugin@0.4.0) (2021-04-17)
 
-
 ### Features
 
 * **heuristic-table:** support react-native-render-html@6.0.0-alpha.23 ([0edee7a](https://github.com/native-html/plugins/commit/0edee7ac2bce532a3f11e7aa5f076b8428694ad3))
 
 ## [0.3.4](https://github.com/native-html/plugins/compare/@native-html/heuristic-table-plugin@0.3.3...@native-html/heuristic-table-plugin@0.3.4) (2021-04-17)
-
 
 ### Bug Fixes
 
@@ -35,13 +47,11 @@
 
 ## [0.3.3](https://github.com/native-html/plugins/compare/@native-html/heuristic-table-plugin@0.3.2...@native-html/heuristic-table-plugin@0.3.3) (2021-04-17)
 
-
 ### Bug Fixes
 
 * restrict compatible versions of react-native-render-html ([032c4ed](https://github.com/native-html/plugins/commit/032c4ed035150471c914d6406fe7b2b2237035fe))
 
 ## [0.3.2](https://github.com/native-html/plugins/compare/@native-html/heuristic-table-plugin@0.3.1...@native-html/heuristic-table-plugin@0.3.2) (2021-03-23)
-
 
 ### Bug Fixes
 
@@ -49,13 +59,11 @@
 
 ## [0.3.1](https://github.com/native-html/plugins/compare/@native-html/heuristic-table-plugin@0.3.0...@native-html/heuristic-table-plugin@0.3.1) (2021-03-04)
 
-
 ### Bug Fixes
 
 * **heuristic-table:** ignoring `overrideContentWidth` option ([8d9224a](https://github.com/native-html/plugins/commit/8d9224ac324e816243d680ae35b05cc66a669d45))
 
 # [0.3.0](https://github.com/native-html/plugins/compare/@native-html/heuristic-table-plugin@0.2.0...@native-html/heuristic-table-plugin@0.3.0) (2021-03-04)
-
 
 ### Features
 
@@ -64,15 +72,12 @@
 
 # [0.2.0](https://github.com/native-html/plugins/compare/@native-html/heuristic-table-plugin@0.1.0...@native-html/heuristic-table-plugin@0.2.0) (2021-02-20)
 
-
 ### Features
 
 * **heuristic-table:** export hooks to reuse internal rendering logic ([d0f1529](https://github.com/native-html/plugins/commit/d0f15298cd6c17799f87d87ff25bb8b6433193bd))
 
 # 0.1.0 (2021-02-18)
 
-
 ### Features
 
 * **heuristic-table:** new 100% native table plugin ([b1ea3f6](https://github.com/native-html/plugins/commit/b1ea3f696cb3f65c9f7cbd56036ab34d1ae08a09))
-

--- a/packages/heuristic-table-plugin/package.json
+++ b/packages/heuristic-table-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-html/heuristic-table-plugin",
-  "version": "0.7.0",
+  "version": "1.0.0-alpha.0",
   "description": "🔠 A 100% native component using heuristics to render tables in @native-html/render",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/heuristic-table-plugin/package.json
+++ b/packages/heuristic-table-plugin/package.json
@@ -38,7 +38,7 @@
     "@babel/runtime": "^7.28.6",
     "@microsoft/api-documenter": "^7.29.6",
     "@microsoft/api-extractor": "7.57.6",
-    "@native-html/render": "1.0.0-alpha.0",
+    "@native-html/render": "1.0.2",
     "@testing-library/react": "16.3.2",
     "@testing-library/react-native": "^13.3.3",
     "@tsconfig/react-native": "^3.0.9",

--- a/packages/iframe-plugin/CHANGELOG.md
+++ b/packages/iframe-plugin/CHANGELOG.md
@@ -1,13 +1,30 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [3.0.0-alpha.0](github.com/native-html/plugins/compare/@native-html/iframe-plugin@2.6.1...@native-html/iframe-plugin@3.0.0-alpha.0) (2026-04-14)
+
+### Bug Fixes
+
+* adjust tests after version bump ([bab83b9](github.com/native-html/plugins/commits/bab83b94a79d2ac9d658c7e44665381ae79f4021)) - by @5ZYSZ3K
+* remove @formidable-webview/ersatz ([d04a6d5](github.com/native-html/plugins/commits/d04a6d5594bf8ca66c419490fd5162dee2e0cff9)) - by @5ZYSZ3K
+* remove WebView tests ([c4e509e](github.com/native-html/plugins/commits/c4e509e83ed6ddb693961532b3489c241973eddb)) - by @5ZYSZ3K
+
+### Features
+
+* fix example app and switch from react-native-render-html to @native-html/render ([5cd0239](github.com/native-html/plugins/commits/5cd0239140bce1610186fcc1a8921f1f35ef4337)) - by @5ZYSZ3K
+* upgrade @native-html/render to a stable version ([bb25566](github.com/native-html/plugins/commits/bb25566282fb604f7fb4f747ec72428934d9f4d0)) - by @5ZYSZ3K
+* upgrade all packages and bring libraries to work ([228ce17](github.com/native-html/plugins/commits/228ce174f2598c2aa6ed9b78fcd1f0d43d439d0a)) - by @5ZYSZ3K
+
 ## [2.6.1](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@2.6.0...@native-html/iframe-plugin@2.6.1) (2021-11-29)
 
 # [2.6.0](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@2.5.0...@native-html/iframe-plugin@2.6.0) (2021-10-13)
-
 
 ### Bug Fixes
 
 * **iframe-plugin:** the iframe is painted as a blank view ([d40e98d](https://github.com/native-html/plugins/commit/d40e98db2595c3d8a231b0070ca3e74d6562fc83)), closes [#41](https://github.com/native-html/plugins/issues/41)
 * remove null from useHtmlIframeProps return signature (dead condition) ([4c51d0a](https://github.com/native-html/plugins/commit/4c51d0af641c0fd121d3959febcc60c09c8259b5))
-
 
 ### Features
 
@@ -15,18 +32,15 @@
 
 # [2.5.0](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@2.4.0...@native-html/iframe-plugin@2.5.0) (2021-06-08)
 
-
 ### Features
 
 * **iframe:** support react-native-render-html@6.0.0-beta.0 ([96c33b5](https://github.com/native-html/plugins/commit/96c33b56ad24a98f76142aad46007d7fbb28699f))
 
 # [2.4.0](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@2.3.0...@native-html/iframe-plugin@2.4.0) (2021-05-21)
 
-
 ### Bug Fixes
 
 * **iframe:** did not pick config passed in rendererProps ([3580d77](https://github.com/native-html/plugins/commit/3580d7781c75ed0a5f3707d5b2fe18c0d8fe6926))
-
 
 ### Features
 
@@ -34,13 +48,11 @@
 
 # [2.3.0](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@2.2.2...@native-html/iframe-plugin@2.3.0) (2021-04-17)
 
-
 ### Features
 
 * **iframe-plugin:** support react-native-render-html@6.0.0-alpha.23 ([489f8f4](https://github.com/native-html/plugins/commit/489f8f4fec58281a2cb1b4180f886a97bddc00d3))
 
 ## [2.2.2](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@2.2.1...@native-html/iframe-plugin@2.2.2) (2021-04-17)
-
 
 ### Bug Fixes
 
@@ -48,18 +60,15 @@
 
 ## [2.2.1](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@2.2.0...@native-html/iframe-plugin@2.2.1) (2021-04-17)
 
-
 ### Bug Fixes
 
 * restrict compatible versions of react-native-render-html ([032c4ed](https://github.com/native-html/plugins/commit/032c4ed035150471c914d6406fe7b2b2237035fe))
 
 # [2.2.0](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@2.1.1...@native-html/iframe-plugin@2.2.0) (2021-02-19)
 
-
 ### Bug Fixes
 
 * force responsive layout when scalesPageToFit = false (1:1) ([1233104](https://github.com/native-html/plugins/commit/12331044fd9f21e443086ca7bd50d37c3ceaa8eb))
-
 
 ### Features
 
@@ -67,13 +76,11 @@
 
 ## [2.1.1](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@2.1.0...@native-html/iframe-plugin@2.1.1) (2021-02-18)
 
-
 ### Bug Fixes
 
 * replace outdated type import `RenderHTMLPassedProps` ([872bc96](https://github.com/native-html/plugins/commit/872bc965d8b5c5e8e37430060a2edc343549623f))
 
 # [2.1.0](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@2.0.2...@native-html/iframe-plugin@2.1.0) (2021-02-08)
-
 
 ### Features
 
@@ -84,7 +91,6 @@
 
 ## [2.0.1](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@2.0.0...@native-html/iframe-plugin@2.0.1) (2021-02-07)
 
-
 ### Bug Fixes
 
 * **iframe-plugin:** pass anchor attributes and target to `onLinkPress` ([a5c22e8](https://github.com/native-html/plugins/commit/a5c22e81f8cff0eba82c363ac453e7118a5e200d))
@@ -92,11 +98,9 @@
 
 # [2.0.0](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@1.1.1...@native-html/iframe-plugin@2.0.0) (2021-02-06)
 
-
 ### Features
 
 * **iframe-plugin:** support react-native-render-html 6.x ([11a8ca0](https://github.com/native-html/plugins/commit/11a8ca04e2e864de145b9189cfb526fb345782ae))
-
 
 ### BREAKING CHANGES
 
@@ -107,13 +111,11 @@
 
 ## [1.1.1](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@1.1.0...@native-html/iframe-plugin@1.1.1) (2020-12-05)
 
-
 ### Bug Fixes
 
 * **iframe-plugin:** resolve TypeError when renderersProp is not defined ([54e650b](https://github.com/native-html/plugins/commit/54e650b9046aeae12f63ed94c41d19347e97d725))
 
 # [1.1.0](https://github.com/native-html/plugins/compare/@native-html/iframe-plugin@1.0.0...@native-html/iframe-plugin@1.1.0) (2020-12-05)
-
 
 ### Features
 
@@ -137,4 +139,3 @@ HTML `contentWidth` prop.) In the screenshot below, scalesPageToFit is disabled
 * **iframe-plugin:** new scalesPageToFit config ([8f5c030](https://github.com/native-html/plugins/commit/8f5c030e7080d2ee861cbbc7db49d214529679f6))
 * **iframe-plugin:** the component inherits from `tagsStyles` and `classesStyles` styles when matched
 * **iframe-plugin:** compliance with React Native Render HTML RFC001: use `computeEmbeddedMaxWidth` to constrain max width for iframes
-

--- a/packages/iframe-plugin/package.json
+++ b/packages/iframe-plugin/package.json
@@ -40,7 +40,7 @@
     "@formidable-webview/ersatz-testing": "^2.0.5",
     "@microsoft/api-documenter": "^7.29.6",
     "@microsoft/api-extractor": "7.57.6",
-    "@native-html/render": "1.0.0-alpha.0",
+    "@native-html/render": "1.0.2",
     "@testing-library/react": "16.3.2",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^30.0.0",

--- a/packages/iframe-plugin/package.json
+++ b/packages/iframe-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-html/iframe-plugin",
-  "version": "2.6.1",
+  "version": "3.0.0-alpha.0",
   "description": "🌐 A WebView-based plugin to render iframes in @native-html/render",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/plugins-core/CHANGELOG.md
+++ b/packages/plugins-core/CHANGELOG.md
@@ -1,5 +1,22 @@
-# [1.3.0](https://github.com/native-html/plugins/compare/@native-html/plugins-core@1.1.0...@native-html/plugins-core@1.3.0) (2021-06-08)
+# Change Log
 
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [2.0.0-alpha.0](github.com/native-html/plugins/compare/@native-html/plugins-core@1.3.0...@native-html/plugins-core@2.0.0-alpha.0) (2026-04-14)
+
+### Bug Fixes
+
+* adjust tests after version bump ([bab83b9](github.com/native-html/plugins/commits/bab83b94a79d2ac9d658c7e44665381ae79f4021)) - by @5ZYSZ3K
+
+### Features
+
+* adds dataAttributes to linkPressTargetToOnDOMLinkPressArgs in plugins-core ([#45](/github.com/native-html/plugins/issues/45)) ([26870f7](github.com/native-html/plugins/commits/26870f796ad4a3ef5d728c460382dfc981e5b2c5)) - by @kioopi
+* fix example app and switch from react-native-render-html to @native-html/render ([5cd0239](github.com/native-html/plugins/commits/5cd0239140bce1610186fcc1a8921f1f35ef4337)) - by @5ZYSZ3K
+* upgrade @native-html/render to a stable version ([bb25566](github.com/native-html/plugins/commits/bb25566282fb604f7fb4f747ec72428934d9f4d0)) - by @5ZYSZ3K
+* upgrade all packages and bring libraries to work ([228ce17](github.com/native-html/plugins/commits/228ce174f2598c2aa6ed9b78fcd1f0d43d439d0a)) - by @5ZYSZ3K
+
+# [1.3.0](https://github.com/native-html/plugins/compare/@native-html/plugins-core@1.1.0...@native-html/plugins-core@1.3.0) (2021-06-08)
 
 ### Features
 
@@ -8,13 +25,11 @@
 
 # [1.2.0](https://github.com/native-html/plugins/compare/@native-html/plugins-core@1.1.0...@native-html/plugins-core@1.2.0) (2021-05-21)
 
-
 ### Features
 
 * support react-native-render-html@6.0.0-alpha.25; beware of upstream breaking changes ([55b2014](https://github.com/native-html/plugins/commit/55b201483ce27a49811727db16624f36e06fc9e4))
 
 # [1.1.0](https://github.com/native-html/plugins/compare/@native-html/plugins-core@1.0.1...@native-html/plugins-core@1.1.0) (2021-04-17)
-
 
 ### Features
 
@@ -22,15 +37,12 @@
 
 ## [1.0.1](https://github.com/native-html/plugins/compare/@native-html/plugins-core@1.0.0...@native-html/plugins-core@1.0.1) (2021-02-18)
 
-
 ### Bug Fixes
 
 * replace outdated type import `RenderHTMLPassedProps` ([872bc96](https://github.com/native-html/plugins/commit/872bc965d8b5c5e8e37430060a2edc343549623f))
 
 # 1.0.0 (2021-02-07)
 
-
 ### Features
 
 * **plugins-core:** new linkPressTargetToOnDOMLinkPressArgs utility ([100384d](https://github.com/native-html/plugins/commit/100384debed5b88ccb1a067712c8e3f340a5659a))
-

--- a/packages/plugins-core/package.json
+++ b/packages/plugins-core/package.json
@@ -31,7 +31,7 @@
     "@babel/runtime": "^7.28.6",
     "@formidable-webview/webshell": "^2.6.0",
     "@microsoft/api-extractor": "7.57.6",
-    "@native-html/render": "1.0.0-alpha.0",
+    "@native-html/render": "1.0.2",
     "@testing-library/react": "16.3.2",
     "@testing-library/react-native": "^13.3.3",
     "@tsconfig/react-native": "^3.0.9",

--- a/packages/plugins-core/package.json
+++ b/packages/plugins-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-html/plugins-core",
-  "version": "1.3.0",
+  "version": "2.0.0-alpha.0",
   "description": "A set of shared utilities for plugins",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/table-plugin/CHANGELOG.md
+++ b/packages/table-plugin/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0-alpha.1](github.com/native-html/plugins/compare/@native-html/table-plugin@6.0.0-alpha.0...@native-html/table-plugin@6.0.0-alpha.1) (2026-04-15)
+
+### Bug Fixes
+
+* remove unnecessary console.log ([7b88648](github.com/native-html/plugins/commits/7b8864853b4d39b2ebd1af6fef955ada99985a7a)) - by @5ZYSZ3K
+
 # [6.0.0-alpha.0](github.com/native-html/plugins/compare/@native-html/table-plugin@5.3.1...@native-html/table-plugin@6.0.0-alpha.0) (2026-04-14)
 
 ### Bug Fixes

--- a/packages/table-plugin/CHANGELOG.md
+++ b/packages/table-plugin/CHANGELOG.md
@@ -1,5 +1,23 @@
-## [5.3.1](https://github.com/native-html/plugins/compare/@native-html/table-plugin@5.3.0...@native-html/table-plugin@5.3.1) (2021-10-13)
+# Change Log
 
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [6.0.0-alpha.0](github.com/native-html/plugins/compare/@native-html/table-plugin@5.3.1...@native-html/table-plugin@6.0.0-alpha.0) (2026-04-14)
+
+### Bug Fixes
+
+* adjust tests after version bump ([bab83b9](github.com/native-html/plugins/commits/bab83b94a79d2ac9d658c7e44665381ae79f4021)) - by @5ZYSZ3K
+* bring back workspace access for @native-html/plugins-core ([d1d8b9c](github.com/native-html/plugins/commits/d1d8b9c8bdea9c49cbec9e894a3d9fde3f1e7ee0)) - by @5ZYSZ3K
+* remove @formidable-webview/ersatz ([d04a6d5](github.com/native-html/plugins/commits/d04a6d5594bf8ca66c419490fd5162dee2e0cff9)) - by @5ZYSZ3K
+
+### Features
+
+* fix example app and switch from react-native-render-html to @native-html/render ([5cd0239](github.com/native-html/plugins/commits/5cd0239140bce1610186fcc1a8921f1f35ef4337)) - by @5ZYSZ3K
+* upgrade @native-html/render to a stable version ([bb25566](github.com/native-html/plugins/commits/bb25566282fb604f7fb4f747ec72428934d9f4d0)) - by @5ZYSZ3K
+* upgrade all packages and bring libraries to work ([228ce17](github.com/native-html/plugins/commits/228ce174f2598c2aa6ed9b78fcd1f0d43d439d0a)) - by @5ZYSZ3K
+
+## [5.3.1](https://github.com/native-html/plugins/compare/@native-html/table-plugin@5.3.0...@native-html/table-plugin@5.3.1) (2021-10-13)
 
 ### Bug Fixes
 
@@ -7,13 +25,11 @@
 
 # [5.3.0](https://github.com/native-html/plugins/compare/@native-html/table-plugin@5.2.0...@native-html/table-plugin@5.3.0) (2021-06-08)
 
-
 ### Features
 
 * **table:** support react-native-render-html@6.0.0-beta.0 ([6de42c8](https://github.com/native-html/plugins/commit/6de42c860fcd2ed0323bd4bd7c86667b134fcf90))
 
 # [5.2.0](https://github.com/native-html/plugins/compare/@native-html/table-plugin@5.1.0...@native-html/table-plugin@5.2.0) (2021-05-21)
-
 
 ### Features
 
@@ -21,13 +37,11 @@
 
 # [5.1.0](https://github.com/native-html/plugins/compare/@native-html/table-plugin@5.0.3...@native-html/table-plugin@5.1.0) (2021-04-17)
 
-
 ### Features
 
 * **table:** support react-native-render-html@6.0.0-alpha.23 ([604e76e](https://github.com/native-html/plugins/commit/604e76e60f99812a558e03ffc17ed877873cf7a4))
 
 ## [5.0.3](https://github.com/native-html/plugins/compare/@native-html/table-plugin@5.0.2...@native-html/table-plugin@5.0.3) (2021-04-17)
-
 
 ### Bug Fixes
 
@@ -35,13 +49,11 @@
 
 ## [5.0.2](https://github.com/native-html/plugins/compare/@native-html/table-plugin@5.0.1...@native-html/table-plugin@5.0.2) (2021-04-17)
 
-
 ### Bug Fixes
 
 * restrict compatible versions of react-native-render-html ([032c4ed](https://github.com/native-html/plugins/commit/032c4ed035150471c914d6406fe7b2b2237035fe))
 
 ## [5.0.1](https://github.com/native-html/plugins/compare/@native-html/table-plugin@5.0.0...@native-html/table-plugin@5.0.1) (2021-02-18)
-
 
 ### Bug Fixes
 
@@ -49,11 +61,9 @@
 
 # [5.0.0](https://github.com/native-html/plugins/compare/@native-html/table-plugin@4.0.3...@native-html/table-plugin@5.0.0) (2021-02-08)
 
-
 ### Features
 
 * **table-plugin:** automatically handle relative URLs ([000b9b4](https://github.com/native-html/plugins/commit/000b9b44de3adb924901bee7fa131542af2b4bc4))
-
 
 ### BREAKING CHANGES
 
@@ -72,7 +82,6 @@ against this base. Read https://git.io/JtwG0 for a detailed description.
 
 ## [4.0.1](https://github.com/native-html/plugins/compare/@native-html/table-plugin@4.0.0...@native-html/table-plugin@4.0.1) (2021-02-07)
 
-
 ### Bug Fixes
 
 * **table-plugin:** default htmlAttribs would cause infinite re-renders ([cb23e01](https://github.com/native-html/plugins/commit/cb23e01d50af19374686632b51d47aa4bd6f532b))
@@ -81,16 +90,13 @@ against this base. Read https://git.io/JtwG0 for a detailed description.
 
 # [4.0.0](https://github.com/native-html/plugins/compare/@native-html/table-plugin@3.1.0...@native-html/table-plugin@4.0.0) (2021-02-06)
 
-
 ### Bug Fixes
 
 * **table-plugin:** mark displayMode field as optional ([b395a49](https://github.com/native-html/plugins/commit/b395a49f0e5d439a799a84393e2c8fd50a239c2c))
 
-
 ### Features
 
 * **table-plugin:** support react-native-render-html 6.x ([1526efe](https://github.com/native-html/plugins/commit/1526efe18b8fd67a51235dca341b34c7227dafa3))
-
 
 ### BREAKING CHANGES
 
@@ -101,7 +107,6 @@ against this base. Read https://git.io/JtwG0 for a detailed description.
 - new `tableModel` export for the new custom renderers API
 
 # [3.1.0](https://github.com/native-html/plugins/compare/@native-html/table-plugin@3.0.1...@native-html/table-plugin@3.1.0) (2020-12-05)
-
 
 ### Features
 
@@ -117,7 +122,6 @@ against this base. Read https://git.io/JtwG0 for a detailed description.
 # 3.0.0 (2020-12-05)
 
 This release requires `react-native-render-html` ≥ 5.0.0! Be aware, its API has changed a little:
-
 
 ```javascript
 import React from 'react';
@@ -214,22 +218,18 @@ Configuration for the table renderer is now read from
 
 # [2.0.0](https://github.com/native-html/table-plugin/compare/v1.0.4...v2.0.0) (2020-09-28)
 
-
 ### Code Refactoring
 
 * implement HTMLTable component with [**webshell 2.0**](https://formidable-webview.github.io/webshell/) `useAutoheight` ([0d038ba](https://github.com/native-html/table-plugin/commit/0d038ba0f61cfa2cd9f089ed7d69d26d191cd4a6)), closes [#16](https://github.com/native-html/table-plugin/issues/16)
-
 
 ### Features
 
 * better customizability of table style specs ([2b66c10](https://github.com/native-html/table-plugin/commit/2b66c10a61990de4a7beb735be0e5be9121c985b)), thanks [@nadav2051](https://github.com/nadav2051)! closes [#10](https://github.com/native-html/table-plugin/issues/10)
 
-
 ### Performance Improvements
 
 * avoid rerendering caused by `onDOMLinkPress` ([1fe9f77](https://github.com/native-html/table-plugin/commit/1fe9f7748851d92935f9fcc7693b5be02f79bfc6))
 * limit number of rendering cycles ([312e648](https://github.com/native-html/table-plugin/commit/312e648b8fb7eddd8c933d6e0b1ba8e35457a910))
-
 
 ### BREAKING CHANGES
 
@@ -240,7 +240,6 @@ Configuration for the table renderer is now read from
 ## [1.0.4](https://github.com/native-html/table-plugin/compare/v1.0.3...v1.0.4) (2020-08-20)
 
 ## [1.0.3](https://github.com/native-html/table-plugin/compare/v1.0.2...v1.0.3) (2020-08-20)
-
 
 ### Bug Fixes
 
@@ -258,11 +257,9 @@ Fix misconfigured repository field in package.json, responsible for bad relative
 
 * restructure source files and comply with api-extractor ([644e2ff](https://github.com/native-html/table-plugin/commit/644e2ff653d5abff979a72ea6cee733227b0baf6))
 
-
 ### Features
 
 * new TableConfig API to configure height computation ([07264fb](https://github.com/native-html/table-plugin/commit/07264fb6233d47cb23ce559c54b83c983e778021))
-
 
 ### BREAKING CHANGES
 
@@ -279,9 +276,7 @@ Finally, `animationDuration` now replaces `transitionDuration` to make the
 semantic link with animationType more explicit.
 * remove export of domToHTML
 
-
 ## [0.6.1](https://github.com/native-html/table-plugin/compare/v0.6.0...v0.6.1) (2020-07-03)
-
 
 ### Bug Fixes
 
@@ -289,13 +284,11 @@ semantic link with animationType more explicit.
 
 # [0.6.0](https://github.com/native-html/table-plugin/compare/v0.5.1...v0.6.0) (2020-07-03)
 
-
 ### Bug Fixes
 
 * empty 'cssRules' prop is ignored ([469ec9a](https://github.com/native-html/table-plugin/commit/469ec9a0665735e64790df9f3724a8411fbe1d83))
 * script injection resulting in syntax error ([875f18f](https://github.com/native-html/table-plugin/commit/875f18f2f24cdc1db6ee79a9487495ecddd92d15))
 * table borders correctly rendered left and bottom ([14422f8](https://github.com/native-html/table-plugin/commit/14422f84cbe2c4e89315119624cd2cc6aeb46198))
-
 
 ### Features
 
@@ -306,7 +299,6 @@ semantic link with animationType more explicit.
 
 - `fitContainer` attribute of `tableStyleSpecs` config has been split into `fitContainerWidth` and `fitContainerHeight`.
 - TypeScript definitions for `react-native-render-html` are not embedded anymore. Please upgrade to `react-native-render-html@4.2.1`.
-
 
 ## 0.5.3
 

--- a/packages/table-plugin/package.json
+++ b/packages/table-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-html/table-plugin",
-  "version": "6.0.0-alpha.0",
+  "version": "6.0.0-alpha.1",
   "description": "🔠 A WebView-based plugin to render tables in @native-html/render",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/table-plugin/package.json
+++ b/packages/table-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-html/table-plugin",
-  "version": "5.3.1",
+  "version": "6.0.0-alpha.0",
   "description": "🔠 A WebView-based plugin to render tables in @native-html/render",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/table-plugin/package.json
+++ b/packages/table-plugin/package.json
@@ -40,7 +40,7 @@
     "@formidable-webview/ersatz-testing": "^2.0.5",
     "@microsoft/api-documenter": "^7.29.6",
     "@microsoft/api-extractor": "7.57.6",
-    "@native-html/render": "1.0.0-alpha.0",
+    "@native-html/render": "1.0.2",
     "@testing-library/react": "16.3.2",
     "@testing-library/react-native": "^13.3.3",
     "@tsconfig/react-native": "^3.0.9",

--- a/packages/table-plugin/src/HTMLTable.tsx
+++ b/packages/table-plugin/src/HTMLTable.tsx
@@ -84,7 +84,6 @@ function findHeight({
   computeHeuristicContentHeight: (tableStats: HTMLTableStats) => number;
   contentHeight: number | null;
 } & HTMLTableStats) {
-  console.log('findHeight');
   if (typeof contentHeight === 'number') {
     return computeContainerHeight({
       type: 'accurate',
@@ -138,15 +137,6 @@ function useAnimatedAutoheight<WVP extends MinimalWebViewProps>({
       webshellProps: webViewProps as any,
       resetHeightOnViewportWidthChange: false
     });
-  console.log({
-    computeContainerHeight,
-    computeHeuristicContentHeight,
-    'contentSize.height': contentSize.height,
-    syncState,
-    numOfChars,
-    numOfColumns,
-    numOfRows
-  });
   const containerHeight = useMemo(
     () =>
       findHeight({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3511,15 +3511,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@native-html/css-processor@npm:2.0.0-alpha.0":
-  version: 2.0.0-alpha.0
-  resolution: "@native-html/css-processor@npm:2.0.0-alpha.0"
+"@native-html/css-processor@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@native-html/css-processor@npm:2.0.0"
   dependencies:
     css-to-react-native: "npm:^3.2.0"
     csstype: "npm:^3.1.3"
   peerDependencies:
     "@types/react": "*"
-  checksum: 10c0/4b290037522a3cf94690cb6f59787260c295b2bf5cee397c4442714db707bf0cdf25aa76a91fb41bbbd0a9098a9c78f9995f5cf2159559283c424f2cffbf7e6d
+  checksum: 10c0/6a552876fe490da5e19f001b73ae68a8a721d2af8958ad714f4af0e28aa8a1d1b67b6415ec2a6f926c4bb6f4e58e9fbf573ef04d357130eea9f3dd7e139a6dc7
   languageName: node
   linkType: hard
 
@@ -3534,7 +3534,7 @@ __metadata:
     "@babel/runtime": "npm:^7.28.6"
     "@microsoft/api-documenter": "npm:^7.29.6"
     "@microsoft/api-extractor": "npm:7.57.6"
-    "@native-html/render": "npm:1.0.0-alpha.0"
+    "@native-html/render": "npm:1.0.2"
     "@testing-library/react": "npm:16.3.2"
     "@testing-library/react-native": "npm:^13.3.3"
     "@tsconfig/react-native": "npm:^3.0.9"
@@ -3578,7 +3578,7 @@ __metadata:
     "@microsoft/api-documenter": "npm:^7.29.6"
     "@microsoft/api-extractor": "npm:7.57.6"
     "@native-html/plugins-core": "workspace:*"
-    "@native-html/render": "npm:1.0.0-alpha.0"
+    "@native-html/render": "npm:1.0.2"
     "@testing-library/react": "npm:16.3.2"
     "@testing-library/react-native": "npm:^13.3.3"
     "@types/jest": "npm:^30.0.0"
@@ -3616,7 +3616,7 @@ __metadata:
     "@babel/runtime": "npm:^7.28.6"
     "@formidable-webview/webshell": "npm:^2.6.0"
     "@microsoft/api-extractor": "npm:7.57.6"
-    "@native-html/render": "npm:1.0.0-alpha.0"
+    "@native-html/render": "npm:1.0.2"
     "@testing-library/react": "npm:16.3.2"
     "@testing-library/react-native": "npm:^13.3.3"
     "@tsconfig/react-native": "npm:^3.0.9"
@@ -3641,13 +3641,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@native-html/render@npm:1.0.0-alpha.0":
-  version: 1.0.0-alpha.0
-  resolution: "@native-html/render@npm:1.0.0-alpha.0"
+"@native-html/render@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@native-html/render@npm:1.0.2"
   dependencies:
     "@jsamr/counter-style": "npm:^2.0.2"
     "@jsamr/react-native-li": "npm:^2.3.1"
-    "@native-html/transient-render-engine": "npm:12.0.0-alpha.0"
+    "@native-html/transient-render-engine": "npm:12.0.0"
     "@types/ramda": "npm:^0.31.1"
     "@types/urijs": "npm:^1.19.25"
     prop-types: "npm:^15.8.1"
@@ -3657,7 +3657,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/d84a83bb1168857af8d4783f4354871ceddc3b46990a5eaf94a3254e70400bdb03ba893cce3a0f48c6d4ec9406170cb2433f50850906a0be4f87c4594cbef564
+  checksum: 10c0/94d292cc41554b2a35edd6de873e593a9daf6d907f40b6fb6af3276346fad2c51fc63ffee18da8e55f694ee8ff25ded0394582be1643c48981da259bd3e4461c
   languageName: node
   linkType: hard
 
@@ -3676,7 +3676,7 @@ __metadata:
     "@microsoft/api-documenter": "npm:^7.29.6"
     "@microsoft/api-extractor": "npm:7.57.6"
     "@native-html/plugins-core": "workspace:*"
-    "@native-html/render": "npm:1.0.0-alpha.0"
+    "@native-html/render": "npm:1.0.2"
     "@testing-library/react": "npm:16.3.2"
     "@testing-library/react-native": "npm:^13.3.3"
     "@tsconfig/react-native": "npm:^3.0.9"
@@ -3705,11 +3705,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@native-html/transient-render-engine@npm:12.0.0-alpha.0":
-  version: 12.0.0-alpha.0
-  resolution: "@native-html/transient-render-engine@npm:12.0.0-alpha.0"
+"@native-html/transient-render-engine@npm:12.0.0":
+  version: 12.0.0
+  resolution: "@native-html/transient-render-engine@npm:12.0.0"
   dependencies:
-    "@native-html/css-processor": "npm:2.0.0-alpha.0"
+    "@native-html/css-processor": "npm:2.0.0"
     csstype: "npm:^3.1.3"
     domelementtype: "npm:^2.3.0"
     domhandler: "npm:^5.0.3"
@@ -3718,7 +3718,7 @@ __metadata:
     ramda: "npm:^0.32.0"
   peerDependencies:
     react-native: "*"
-  checksum: 10c0/61e848f81ab495b848fd75a0bcd91517f5dcefb44f8764af3886e53f6cf33888f0a9ee20f304f0fb5888b6be860ce64673a44f62626c33371bcc1398921fb577
+  checksum: 10c0/bd530e4c43afc3035c8247e76673bfb211d4c08234e6d47a4e4e1c3a040b66bae2e8fd5f95c813c9879959c1399a96ea8c73974255fe9ea6ff5b1e31313c37f4
   languageName: node
   linkType: hard
 
@@ -8117,7 +8117,7 @@ __metadata:
     "@native-html/heuristic-table-plugin": "workspace:*"
     "@native-html/iframe-plugin": "workspace:*"
     "@native-html/plugins-core": "workspace:*"
-    "@native-html/render": "npm:1.0.0-alpha.0"
+    "@native-html/render": "npm:1.0.2"
     "@native-html/table-plugin": "workspace:*"
     "@react-native-community/masked-view": "npm:0.1.11"
     "@react-navigation/native": "npm:^7.1.31"


### PR DESCRIPTION
Successfully published: 
 - @native-html/heuristic-table-plugin@1.0.0-alpha.0
 - @native-html/iframe-plugin@3.0.0-alpha.0
 - @native-html/plugins-core@2.0.0-alpha.0
 - @native-html/table-plugin@6.0.0-alpha.0

Also, changed `@native-html/render` to a stable version (there were no changes between the alpha and the stable version)

Closes #57 